### PR TITLE
Added functionality to ask users if they are sure they want to delete…

### DIFF
--- a/app/src/main/java/com/sluglet/slugletapp/common/composables/ButtonComposables.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/common/composables/ButtonComposables.kt
@@ -1,0 +1,57 @@
+package com.sluglet.slugletapp.common.composables
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun BasicTextButton(@StringRes text: Int, modifier: Modifier, action: () -> Unit) {
+    TextButton(onClick = action, modifier = modifier) { Text(text = stringResource(text)) }
+}
+
+@Composable
+fun BasicButton(@StringRes text: Int, modifier: Modifier, action: () -> Unit) {
+    Button(
+        onClick = action,
+        modifier = modifier,
+        colors =
+        ButtonDefaults.buttonColors(
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        Text(text = stringResource(text), fontSize = 16.sp)
+    }
+}
+
+@Composable
+fun DialogConfirmButton(@StringRes text: Int, action: () -> Unit) {
+    Button(
+        onClick = action,
+        colors =
+        ButtonDefaults.buttonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface
+        )
+    ) {
+        Text(text = stringResource(text))
+    }
+}
+
+@Composable
+fun DialogCancelButton(@StringRes text: Int, action: () -> Unit) {
+    Button(
+        onClick = action,
+        colors =
+        ButtonDefaults.buttonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface
+        )
+    ) {
+        Text(text = stringResource(text))
+    }
+}

--- a/app/src/main/java/com/sluglet/slugletapp/model/service/StorageService.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/model/service/StorageService.kt
@@ -16,6 +16,7 @@ interface StorageService {
     suspend fun storeUserData(user: User)
     suspend fun retrieveUserData(id: String): User?
     suspend fun getCourseData(courseId: String, onSuccess: (CourseData) -> Unit, onError: (String) -> Unit)
+    suspend fun deleteUser(userId: String)
     /*
     // FIXME: I don't think we need these since user shouldn't be able to manipulate courses
     suspend fun save(course: CourseData): String

--- a/app/src/main/java/com/sluglet/slugletapp/model/service/impl/AccountServiceImpl.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/model/service/impl/AccountServiceImpl.kt
@@ -114,7 +114,6 @@ class AccountServiceImpl @Inject constructor(
             }
     }
     override suspend fun deleteAccount() {
-        firestore.collection(USER_COLLECTION).document(currentUserId).delete().await()
         auth.currentUser!!.delete().await()
     }
 
@@ -128,7 +127,8 @@ class AccountServiceImpl @Inject constructor(
         // createAnonymousAccount()
     }
     /**
-     * Links the current account to the provided matching parameters
+     * Links the current account to the provided matching parameters.
+     * Also updates the users document in Firestore with the email provided.
      *
      * @param email The email associated with the account to be linked to
      * @param password The password associated with the account to be linked to
@@ -139,7 +139,7 @@ class AccountServiceImpl @Inject constructor(
     ) {
         val credential = EmailAuthProvider.getCredential(email, password)
         auth.currentUser!!.linkWithCredential(credential).await()
-        firestore.collection(USER_COLLECTION).document(currentUserId).update("email", email).await()
+        firestore.collection(USER_COLLECTION).document(currentUserId).update(EMAIL_FIELD, email).await()
     }
 
     override fun isUserAnonymous(): Boolean {
@@ -152,5 +152,6 @@ class AccountServiceImpl @Inject constructor(
 
     companion object {
         private const val USER_COLLECTION = "users"
+        private const val EMAIL_FIELD = "email"
     }
 }

--- a/app/src/main/java/com/sluglet/slugletapp/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/screens/settings/SettingsScreen.kt
@@ -19,8 +19,12 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
+import androidx.compose.ui.res.stringResource
+import com.sluglet.slugletapp.common.composables.DialogCancelButton
+import com.sluglet.slugletapp.common.composables.DialogConfirmButton
 import com.sluglet.slugletapp.common.ext.basicRow
 import com.sluglet.slugletapp.common.ext.smallSpacer
+import com.sluglet.slugletapp.R.string as AppText
 
 @Composable
 fun SettingsScreen (
@@ -35,9 +39,9 @@ fun SettingsScreen (
         uiState = uiState,
         onLoginClick = { viewModel.onLoginClick(openScreen) },
         onSignUpClick = { viewModel.onSignUpClick(openScreen) },
-        onSignOutClick = { viewModel.onSignOutClick(restartApp) }
-
-    ) { viewModel.onDeleteMyAccountClick(restartApp) }
+        onSignOutClick = { viewModel.onSignOutClick(restartApp) },
+        onDeleteMyAccountClick = { viewModel.onDeleteMyAccountClick(restartApp) }
+    )
 }
 @Composable
 fun SettingsScreenContent (
@@ -63,7 +67,7 @@ fun SettingsScreenContent (
             TextButton(onClick = onLoginClick, text = "Login")
         }else {
             TextButton (onClick = onSignOutClick, text = "Log Out")
-            TextButton (onClick = onDeleteMyAccountClick, text = "Delete Account")
+            TextButton (onClick = onDeleteMyAccountClick, text = "Delete Account", isDeleteButton = true)
         }
     }
 }
@@ -72,15 +76,42 @@ fun SettingsScreenContent (
 @Composable
 fun TextButton(
     onClick: () -> Unit,
-    text: String
+    text: String,
+    isDeleteButton: Boolean = false
 ){
-    Card(
-        onClick = { onClick() },
-        modifier = Modifier.padding(5.dp).basicRow()
-    ) {
-        Text(text = text, color = Color.Black, modifier = Modifier.smallSpacer())
+    if (!isDeleteButton) {
+        Card(
+            onClick = { onClick() },
+            modifier = Modifier.padding(5.dp).basicRow()
+        ) {
+            Text(text = text, color = Color.Black, modifier = Modifier.smallSpacer())
+        }
+    }
+    else  {
+        var showWarningDialog by remember { mutableStateOf(false) }
+        Card(
+            onClick = { showWarningDialog = true },
+            modifier = Modifier.padding(5.dp).basicRow()
+        ) {
+            Text(text = text, color = Color.Black, modifier = Modifier.smallSpacer())
+        }
+        if (showWarningDialog) {
+            AlertDialog(
+                title = { Text(stringResource(AppText.delete_account_title)) },
+                text = { Text(stringResource(AppText.delete_account_description)) },
+                dismissButton = { DialogCancelButton(AppText.cancel) { showWarningDialog = false } },
+                confirmButton = {
+                    DialogConfirmButton(AppText.delete_my_account) {
+                        onClick()
+                        showWarningDialog = false
+                    }
+                },
+                onDismissRequest = { showWarningDialog = false }
+            )
+        }
     }
 }
+
 @Composable
 fun ReturnButton(
     onReturnClick: (((String) -> Unit) -> Unit)?,

--- a/app/src/main/java/com/sluglet/slugletapp/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/screens/settings/SettingsViewModel.kt
@@ -2,9 +2,12 @@ package com.sluglet.slugletapp.screens.settings
 
 import com.sluglet.slugletapp.HOME_SCREEN
 import com.sluglet.slugletapp.SIGNUP_SCREEN
+import com.sluglet.slugletapp.common.snackbar.SnackbarManager
 import com.sluglet.slugletapp.model.service.AccountService
 import com.sluglet.slugletapp.model.service.LogService
+import com.sluglet.slugletapp.model.service.StorageService
 import com.sluglet.slugletapp.screens.SlugletViewModel
+import com.sluglet.slugletapp.R.string as AppText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
@@ -12,14 +15,27 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     logService: LogService,
-    private val accountService: AccountService
+    private val accountService: AccountService,
+    private val storageService: StorageService
 ) : SlugletViewModel(logService) {
     val uiState = MutableStateFlow(SettingsUiState(accountService.isUserAnonymous()))
 
+    /**
+     * Opens the signup screen where the user can login
+     * @param openScreen The screen to open
+     */
     fun onLoginClick(openScreen: (String) -> Unit) = openScreen(SIGNUP_SCREEN)
-
+    /**
+     * Opens the signup screen where the user can sign up
+     * @param openScreen The screen to open
+     */
     fun onSignUpClick(openScreen: (String) -> Unit) = openScreen(SIGNUP_SCREEN)
 
+    /**
+     * Signs a user out and restarts the app from the Home Screen
+     * @param restartApp Indicates the screen to open after deletion and pops all screens from the
+     * backstack, effectively restarting the app.
+     */
     fun onSignOutClick(restartApp: (String) -> Unit) {
         launchCatching {
             accountService.signOut()
@@ -27,10 +43,21 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Calls services to delete the current user's account from Auth and Firestore.
+     * Since all services are called within a launchCatching block, any exceptions
+     * that may occur will be handled and the rest of the block will be aborted.
+     *
+     * @param restartApp Indicates the screen to open after deletion and pops all screens from the
+     * backstack, effectively restarting the app.
+     */
     fun onDeleteMyAccountClick(restartApp: (String) -> Unit) {
         launchCatching {
+            val userId = accountService.currentUserId
             accountService.deleteAccount()
+            storageService.deleteUser(userId)
             restartApp(HOME_SCREEN)
+            SnackbarManager.showMessage(AppText.deleted_account)
         }
     }
 

--- a/app/src/main/java/com/sluglet/slugletapp/screens/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/sluglet/slugletapp/screens/sign_up/SignUpViewModel.kt
@@ -37,6 +37,11 @@ class SignUpViewModel @Inject constructor(
         _uiState.value = uiState.value.copy(password = newValue)
     }
 
+    /**
+     * Calls services to link Anonymous user to an account with the provided credentials
+     * @param openAndPopUp Indicates which screen to open and pops this screen from the
+     * backstack.
+     */
     fun onSignUpClick(openAndPopUp: (String, String) -> Unit) {
         if (!(email).isValidEmail()) {
             SnackbarManager.showMessage(AppText.email_error)
@@ -48,30 +53,18 @@ class SignUpViewModel @Inject constructor(
             return
         }
 
-        /*
-        Tries to authenticate, and if the call succeeds,
-        it proceeds to the next screen (the SettingsScreen).
-        As you are executing these calls inside a launchCatching block,
-        if an error happens on the first line,
-        the exception will be caught and handled,
-        and the second line will not be reached at all.
-         */
         launchCatching {
             accountService.linkAccounts(_uiState.value.email, _uiState.value.password)
-            // FIXME: Now with anonymous accounts, we maybe don't need this
-            accountService.createAccount(_uiState.value.email, _uiState.value.password)
             openAndPopUp(HOME_SCREEN, SIGNUP_SCREEN)
         }
     }
-    fun onSignInClick(openAndPopUp: (String, String) -> Unit) {
-    /*
-    Tries to authenticate, and if the call succeeds,
-    it proceeds to the next screen (the SettingsScreen).
-    As you are executing these calls inside a launchCatching block,
-    if an error happens on the first line,
-    the exception will be caught and handled,
-    and the second line will not be reached at all.
+
+    /**
+     * Calls services to log a user into their account.
+     * @param openAndPopUp Indicates which screen to open and pops this screen from the
+     * backstack.
      */
+    fun onSignInClick(openAndPopUp: (String, String) -> Unit) {
         if (!(email).isValidEmail()) {
             SnackbarManager.showMessage(AppText.email_error)
             return

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,18 @@
     <string name="cancel">Cancel</string>
     <string name="try_again">Try again</string>
     <string name="ok">OK</string>
+    <string name="deleted_account">Account Deleted</string>
+
+    <!-- SettingsScreen -->
+    <string name="settings">Settings</string>
+    <string name="sign_out">Sign out</string>
+    <string name="delete_my_account">Delete my account</string>
+
+    <!-- Dialogs -->
+    <string name="sign_out_title">Sign out?</string>
+    <string name="sign_out_description">You will have to sign in again to see your tasks.</string>
+    <string name="delete_account_title">Delete account?</string>
+    <string name="delete_account_description">You will lose all your courses and your account will be deleted. This action is irreversible.</string>
 
     <!-- LoginScreen -->
     <string name="sign_in">Sign in</string>


### PR DESCRIPTION
… their account on delete click, refactored deletion to call two services: One call to accountService to delete the user from Auth in firebase, another call to storageService to delete that users document from firestore.  These calls are nested in a launchCatching block so that, if the call to delete the account from Auth fails, the callto delete the users document will not execute.  On success, the user sees a snackbar message informing them of successful deletion of their account.  The call to createAccount in signup is no longer used since this is handled in HomeViewModel when creating an anonymous user.  Once the user signs up, all that is needed is to link the account.